### PR TITLE
Add script to conditionally run C# program

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,19 @@
+// Simple C# console program
+// Prints a greeting and sums two integers
+using System;
+
+namespace Projekt1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            int a = 3;
+            int b = 4;
+            int sum = a + b;
+            Console.WriteLine("Sum of {0} and {1} is {2}", a, b, sum);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Projekt1
-Test
+
+Dieses Repository enthält ein simples Beispielprogramm in C#.
+
+Die Datei `Program.cs` implementiert ein kleines Konsolenprogramm. Beim Start gibt es eine Begrüßung aus und berechnet anschließend die Summe zweier Zahlen. Das Ergebnis wird auf der Konsole ausgegeben.
+
+## Ausführen des Programms
+
+Um das Programm zu kompilieren und auszuführen wird normalerweise die .NET SDK benötigt. In dieser Umgebung ist keine entsprechende Laufzeit installiert. Das Skript `run.sh` prüft, ob `dotnet` oder `csc` mit `mono` vorhanden ist. Falls nicht, wird eine Meldung ausgegeben und das Skript beendet sich ohne Fehler.
+
+```bash
+./run.sh
+```
+
+Beispielhafter manueller Aufruf, falls die Laufzeit vorhanden ist:
+
+```bash
+csc Program.cs
+mono Program.exe
+# oder falls .NET Core installiert ist
+dotnet run Program.cs
+```

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if command -v dotnet > /dev/null; then
+    dotnet run Program.cs
+elif command -v csc > /dev/null && command -v mono > /dev/null; then
+    csc Program.cs && mono Program.exe
+else
+    echo "C# runtime not found. Skipping run."
+fi


### PR DESCRIPTION
## Summary
- add a small bash helper `run.sh` which only runs the program if `dotnet` or `csc`+`mono` are available
- update `README` with simplified instructions referencing the script

## Testing
- `./run.sh`
- `csc Program.cs` *(fails: command not found)*
- `dotnet run Program.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd885b98c832cb8432420ed3a3e64