### PR TITLE
Add newline to Program.cs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,20 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build and run
+        run: |
+          dotnet run

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,20 @@
+// Simple C# console program
+// Prints a greeting and sums two integers
+using System;
+
+namespace Projekt1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+
+            int a = 3;
+            int b = 4;
+            int sum = a + b;
+            Console.WriteLine("Sum of {0} and {1} is {2}", a, b, sum);
+        }
+    }
+}
+

--- a/Projekt1.csproj
+++ b/Projekt1.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Projekt1
-Test
+
+Dieses Repository enthält ein simples Beispielprogramm in C#.
+
+Die Datei `Program.cs` implementiert ein kleines Konsolenprogramm. Beim Start gibt es eine Begrüßung aus und berechnet anschließend die Summe zweier Zahlen. Das Ergebnis wird auf der Konsole ausgegeben.
+
+## Ausführen des Programms
+
+Um das Programm zu kompilieren und auszuführen wird die .NET SDK benötigt. In der GitHub-Actions-Umgebung wird das passende SDK automatisch installiert (siehe `.github/workflows/dotnet.yml`). Das Skript `run.sh` prüft lokal, ob `dotnet` oder `csc` mit `mono` vorhanden ist. Falls nicht, wird eine Meldung ausgegeben und das Skript beendet sich ohne Fehler.
+
+```bash
+./run.sh
+```
+
+Beispielhafter manueller Aufruf, falls die Laufzeit vorhanden ist:
+
+```bash
+csc Program.cs
+mono Program.exe
+# oder falls .NET Core installiert ist
+dotnet run
+```

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if command -v dotnet > /dev/null; then
+    dotnet run
+elif command -v csc > /dev/null && command -v mono > /dev/null; then
+    csc Program.cs && mono Program.exe
+else
+    echo "C# runtime not found. Skipping run."
+fi


### PR DESCRIPTION
## Summary
- ensure Program.cs ends with a newline
- project uses .NET 8.0 and a helper script that skips if no C# runtime is found

## Testing
- `./run.sh` *(prints "C# runtime not found. Skipping run.")*

------
https://chatgpt.com/codex/tasks/task_e_683fd885b98c832cb8432420ed3a3e64