### PR TITLE
Improve run script error handling

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 if command -v dotnet > /dev/null; then
     dotnet run Program.cs
 elif command -v csc > /dev/null && command -v mono > /dev/null; then
     csc Program.cs && mono Program.exe
 else
-    echo "C# runtime not found. Skipping run."
+    echo "Neither 'dotnet' nor 'csc' with 'mono' found. Skipping run."
 fi


### PR DESCRIPTION
## Summary
- add `set -euo pipefail` to abort on errors
- clarify message when C# runtime is unavailable

## Testing
- `bash run.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fe3de9e94832c93658c7d4add30ae